### PR TITLE
PS-1561 -  Add helper methods

### DIFF
--- a/openinghours.go
+++ b/openinghours.go
@@ -269,22 +269,22 @@ func GetOCPIOpeningTimes(ohs []OpeningHours) OCPIOpeningTimes {
 // (e.g., "monday", "tuesday") to the corresponding time.Weekday value.
 func ParseStringWeekdayToTimeWeekday(dayStr string) (time.Weekday, error) {
 	switch strings.ToLower(dayStr) {
-	case "monday":
+	case "monday", "mon":
 		return time.Monday, nil
-	case "tuesday":
+	case "tuesday", "tue":
 		return time.Tuesday, nil
-	case "wednesday":
+	case "wednesday", "wed":
 		return time.Wednesday, nil
-	case "thursday":
+	case "thursday", "thu":
 		return time.Thursday, nil
-	case "friday":
+	case "friday", "fri":
 		return time.Friday, nil
-	case "saturday":
+	case "saturday", "sat":
 		return time.Saturday, nil
-	case "sunday":
+	case "sunday", "sun":
 		return time.Sunday, nil
 	default:
-		return time.Sunday, fmt.Errorf("invalid weekday: %s", dayStr)
+		return time.Weekday(-1), fmt.Errorf("invalid weekday: %s", dayStr)
 	}
 }
 

--- a/openinghours.go
+++ b/openinghours.go
@@ -79,6 +79,7 @@ func (oh OpeningHours) String() string {
 	return fmt.Sprintf("%s/%s", open, close)
 }
 
+// OpeningHoursSliceToString converts a slice of OpeningHours into a single string representation like "W1T08:00:00/W1T16:00:00,W2T06:00:00/W2T20:00:00".
 func OpeningHoursSliceToString(ohs []OpeningHours) string {
 	openingHoursStr := make([]string, len(ohs))
 	for i, openingHours := range ohs {

--- a/openinghours.go
+++ b/openinghours.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // OpeningHours contains an opening and closing times within a given week. The
@@ -76,6 +77,15 @@ func (oh OpeningHours) String() string {
 	}
 
 	return fmt.Sprintf("%s/%s", open, close)
+}
+
+func OpeningHoursSliceToString(ohs []OpeningHours) string {
+	openingHoursStr := make([]string, len(ohs))
+	for i, openingHours := range ohs {
+		openingHoursStr[i] = openingHours.String()
+	}
+
+	return strings.Join(openingHoursStr, ",")
 }
 
 // ParseOpeningHours does the opposite of OpeningHours.String method. It converts a string like

--- a/openinghours.go
+++ b/openinghours.go
@@ -254,6 +254,49 @@ func GetOCPIOpeningTimes(ohs []OpeningHours) OCPIOpeningTimes {
 	}
 }
 
+// ParseStringWeekdayToTimeWeekday converts a string representation of a weekday
+// (e.g., "monday", "tuesday") to the corresponding time.Weekday value.
+func ParseStringWeekdayToTimeWeekday(dayStr string) (time.Weekday, error) {
+	switch strings.ToLower(dayStr) {
+	case "monday":
+		return time.Monday, nil
+	case "tuesday":
+		return time.Tuesday, nil
+	case "wednesday":
+		return time.Wednesday, nil
+	case "thursday":
+		return time.Thursday, nil
+	case "friday":
+		return time.Friday, nil
+	case "saturday":
+		return time.Saturday, nil
+	case "sunday":
+		return time.Sunday, nil
+	default:
+		return time.Sunday, fmt.Errorf("invalid weekday: %s", dayStr)
+	}
+}
+
+// ParseMinutesSinceMidnight parses hours and minutes strings into total minutes since midnight.
+// e.g. ("08", "30") -> 510
+func ParseMinutesSinceMidnight(v1, v2 string) (int, error) {
+	hours, err := strconv.Atoi(v1)
+	if err != nil || (hours < 0 || hours > 24) {
+		return 0, fmt.Errorf("invalid hours value")
+	}
+
+	minutes, err := strconv.Atoi(v2)
+	if err != nil || (minutes < 0 || minutes > 59) {
+		return 0, fmt.Errorf("invalid minutes value")
+	}
+
+	if hours == 24 && minutes != 0 {
+		return 0, fmt.Errorf("invalid value")
+	}
+
+	return hours*60 + minutes, nil
+}
+
 func isTwentyFourSeven(ohs []OpeningHours) bool {
 	if len(ohs) == 0 {
 		return false
@@ -299,7 +342,7 @@ func parseTimeInWeek(v string) (*TimeInWeek, error) {
 		return nil, fmt.Errorf("invalid workday in `%s`: expected to be between 1 (monday) and 7 (sunday)", v)
 	}
 
-	minutesSinceMidnight, err := parseMinutesSinceMidnight(matches[2], matches[3])
+	minutesSinceMidnight, err := ParseMinutesSinceMidnight(matches[2], matches[3])
 	if err != nil {
 		return nil, fmt.Errorf("invalid time in `%s`: %s", v, err)
 	}
@@ -340,24 +383,6 @@ func getWeekDay(weekday int) string {
 	default:
 		return ""
 	}
-}
-
-func parseMinutesSinceMidnight(v1, v2 string) (int, error) {
-	hours, err := strconv.Atoi(v1)
-	if err != nil || (hours < 0 || hours > 24) {
-		return 0, fmt.Errorf("invalid hours value")
-	}
-
-	minutes, err := strconv.Atoi(v2)
-	if err != nil || (minutes < 0 || minutes > 59) {
-		return 0, fmt.Errorf("invalid minutes value")
-	}
-
-	if hours == 24 && minutes != 0 {
-		return 0, fmt.Errorf("invalid value")
-	}
-
-	return hours*60 + minutes, nil
 }
 
 func minutesSinceMidnightToTime(minutesSinceMidnight int) string {

--- a/openinghours_test.go
+++ b/openinghours_test.go
@@ -12,89 +12,89 @@ func TestOpeningHoursString(t *testing.T) {
 		openingHours   OpeningHours
 		expectedResult string
 	}{
-	"when monday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
-			Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+		"when monday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+				Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+			},
+			expectedResult: "W1T08:00:00/W1T16:00:00",
 		},
-		expectedResult: "W1T08:00:00/W1T16:00:00",
+		"when tuesday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
+				Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+			},
+			expectedResult: "W2T06:00:00/W2T20:00:00",
 		},
-	"when tuesday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
-			Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+		"when wednesday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 480},
+				Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 960},
+			},
+			expectedResult: "W3T08:00:00/W3T16:00:00",
 		},
-		expectedResult: "W2T06:00:00/W2T20:00:00",
+		"when thursday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 490},
+				Close: &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 975},
+			},
+			expectedResult: "W4T08:10:00/W4T16:15:00",
 		},
-	"when wednesday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 480},
-			Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 960},
+		"when friday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 630},
+				Close: &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 780},
+			},
+			expectedResult: "W5T10:30:00/W5T13:00:00",
 		},
-		expectedResult: "W3T08:00:00/W3T16:00:00",
+		"when saturday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 480},
+				Close: &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 960},
+			},
+			expectedResult: "W6T08:00:00/W6T16:00:00",
 		},
-	"when thursday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 490},
-			Close: &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 975},
+		"when sunday": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 480},
+				Close: &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 960},
+			},
+			expectedResult: "W7T08:00:00/W7T16:00:00",
 		},
-		expectedResult: "W4T08:10:00/W4T16:15:00",
+		"when closing time is during the next day": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+				Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 240},
+			},
+			expectedResult: "W2T20:00:00/W3T04:00:00",
 		},
-	"when friday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 630},
-			Close: &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 780},
+		"when opening hours not specified": {
+			openingHours: OpeningHours{
+				Open:  nil,
+				Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+			},
+			expectedResult: "/W1T16:00:00",
 		},
-		expectedResult: "W5T10:30:00/W5T13:00:00",
+		"when closing hours not specified": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+				Close: nil,
+			},
+			expectedResult: "W1T08:00:00/",
 		},
-	"when saturday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 480},
-			Close: &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 960},
+		"when opening and closing hours not specified": {
+			openingHours: OpeningHours{
+				Open:  nil,
+				Close: nil,
+			},
+			expectedResult: "/",
 		},
-		expectedResult: "W6T08:00:00/W6T16:00:00",
-		},
-	"when sunday": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 480},
-			Close: &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 960},
-		},
-		expectedResult: "W7T08:00:00/W7T16:00:00",
-		},
-	"when closing time is during the next day": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
-			Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 240},
-		},
-		expectedResult: "W2T20:00:00/W3T04:00:00",
-		},
-	"when opening hours not specified": {
-		openingHours: OpeningHours{
-			Open:  nil,
-			Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
-		},
-		expectedResult: "/W1T16:00:00",
-		},
-	"when closing hours not specified": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
-			Close: nil,
-		},
-		expectedResult: "W1T08:00:00/",
-		},
-	"when opening and closing hours not specified": {
-		openingHours: OpeningHours{
-			Open:  nil,
-			Close: nil,
-		},
-		expectedResult: "/",
-		},
-	"when weekday invalid": {
-		openingHours: OpeningHours{
-			Open:  &TimeInWeek{Weekday: 10, MinutesSinceMidnight: 480},
-			Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
-		},
-		expectedResult: "W10T08:00:00/W1T16:00:00",
+		"when weekday invalid": {
+			openingHours: OpeningHours{
+				Open:  &TimeInWeek{Weekday: 10, MinutesSinceMidnight: 480},
+				Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+			},
+			expectedResult: "W10T08:00:00/W1T16:00:00",
 		},
 	}
 
@@ -110,200 +110,252 @@ func TestOpeningHoursString(t *testing.T) {
 	}
 }
 
+func TestOpeningHoursSliceToString(t *testing.T) {
+	tests := map[string]struct {
+		openingHours   []OpeningHours
+		expectedResult string
+	}{
+		"single monday": {
+			openingHours: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+				},
+			},
+			expectedResult: "W1T08:00:00/W1T16:00:00",
+		},
+		"single tuesday": {
+			openingHours: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
+					Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+				},
+			},
+			expectedResult: "W2T06:00:00/W2T20:00:00",
+		},
+		"multiple days": {
+			openingHours: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+				},
+				{
+					Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
+					Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+				},
+			},
+			expectedResult: "W1T08:00:00/W1T16:00:00,W2T06:00:00/W2T20:00:00",
+		},
+		"empty slice": {
+			openingHours:   []OpeningHours{},
+			expectedResult: "",
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			result := OpeningHoursSliceToString(tt.openingHours)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
 func TestParseOpeningHours(t *testing.T) {
 	tests := map[string]struct {
 		openingHours   string
 		expectedResult []OpeningHours
 		expectedError  error
 	}{
-	"when monday": {
-		openingHours: "W1T08:00:00/W1T16:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
-				Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+		"when monday": {
+			openingHours: "W1T08:00:00/W1T16:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when tuesday": {
-		openingHours: "W2T06:00:00/W2T20:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
-				Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+		"when tuesday": {
+			openingHours: "W2T06:00:00/W2T20:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
+					Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when wednesday": {
-		openingHours: "W3T08:00:00/W3T16:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 480},
-				Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 960},
+		"when wednesday": {
+			openingHours: "W3T08:00:00/W3T16:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 960},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when thursday": {
-		openingHours: "W4T08:10:00/W4T16:15:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 490},
-				Close: &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 975},
+		"when thursday": {
+			openingHours: "W4T08:10:00/W4T16:15:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 490},
+					Close: &TimeInWeek{Weekday: 4, MinutesSinceMidnight: 975},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when friday": {
-		openingHours: "W5T10:30:00/W5T13:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 630},
-				Close: &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 780},
+		"when friday": {
+			openingHours: "W5T10:30:00/W5T13:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 630},
+					Close: &TimeInWeek{Weekday: 5, MinutesSinceMidnight: 780},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when saturday": {
-		openingHours: "W6T08:00:00/W6T16:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 480},
-				Close: &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 960},
+		"when saturday": {
+			openingHours: "W6T08:00:00/W6T16:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 6, MinutesSinceMidnight: 960},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when sunday": {
-		openingHours: "W7T08:00:00/W7T16:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 480},
-				Close: &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 960},
+		"when sunday": {
+			openingHours: "W7T08:00:00/W7T16:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 960},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when closing time is during the next day": {
-		openingHours: "W2T20:00:00/W3T04:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
-				Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 240},
+		"when closing time is during the next day": {
+			openingHours: "W2T20:00:00/W3T04:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+					Close: &TimeInWeek{Weekday: 3, MinutesSinceMidnight: 240},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when opening hours not specified": {
-		openingHours: "/W1T16:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  nil,
-				Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+		"when opening hours not specified": {
+			openingHours: "/W1T16:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  nil,
+					Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when closing hours not specified": {
-		openingHours: "W1T08:00:00/",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
-				Close: nil,
+		"when closing hours not specified": {
+			openingHours: "W1T08:00:00/",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+					Close: nil,
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when opening and closing hours not specified": {
-		openingHours: "/",
-		expectedResult: []OpeningHours{
-			{
-				Open:  nil,
-				Close: nil,
+		"when opening and closing hours not specified": {
+			openingHours: "/",
+			expectedResult: []OpeningHours{
+				{
+					Open:  nil,
+					Close: nil,
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when whole week": {
-		openingHours: "W1T00:00:00/W7T24:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 0},
-				Close: &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 1440},
+		"when whole week": {
+			openingHours: "W1T00:00:00/W7T24:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 0},
+					Close: &TimeInWeek{Weekday: 7, MinutesSinceMidnight: 1440},
+				},
 			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-		},
-	"when multiple opening hours": {
-		openingHours: "W1T08:00:00/W1T16:00:00,W2T06:00:00/W2T20:00:00",
-		expectedResult: []OpeningHours{
-			{
-				Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
-				Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+		"when multiple opening hours": {
+			openingHours: "W1T08:00:00/W1T16:00:00,W2T06:00:00/W2T20:00:00",
+			expectedResult: []OpeningHours{
+				{
+					Open:  &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 480},
+					Close: &TimeInWeek{Weekday: 1, MinutesSinceMidnight: 960},
+				},
+				{
+					Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
+					Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
+				},
 			},
-			{
-				Open:  &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 360},
-				Close: &TimeInWeek{Weekday: 2, MinutesSinceMidnight: 1200},
-			},
+			expectedError: nil,
 		},
-		expectedError: nil,
+		"when string empty": {
+			openingHours:   "",
+			expectedResult: []OpeningHours{},
+			expectedError:  nil,
 		},
-	"when string empty": {
-		openingHours:   "",
-		expectedResult: []OpeningHours{},
-		expectedError:  nil,
+		"when string invalid": {
+			openingHours:   "invalid",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid opening hours string `invalid`"),
 		},
-	"when string invalid": {
-		openingHours:   "invalid",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid opening hours string `invalid`"),
+		"when opening string invalid": {
+			openingHours:   "invalid/W1T16:00:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid opening hours: invalid value `invalid`"),
 		},
-	"when opening string invalid": {
-		openingHours:   "invalid/W1T16:00:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid opening hours: invalid value `invalid`"),
+		"when opening weekday invalid": {
+			openingHours:   "W9T08:00:00/W1T16:00:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid opening hours: invalid workday in `W9T08:00:00`: expected to be between 1 (monday) and 7 (sunday)"),
 		},
-	"when opening weekday invalid": {
-		openingHours:   "W9T08:00:00/W1T16:00:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid opening hours: invalid workday in `W9T08:00:00`: expected to be between 1 (monday) and 7 (sunday)"),
+		"when opening hours invalid": {
+			openingHours:   "W1T99:00:00/W1T16:00:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid opening hours: invalid time in `W1T99:00:00`: invalid hours value"),
 		},
-	"when opening hours invalid": {
-		openingHours:   "W1T99:00:00/W1T16:00:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid opening hours: invalid time in `W1T99:00:00`: invalid hours value"),
+		"when opening minutes invalid": {
+			openingHours:   "W1T08:99:00/W1T16:00:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid opening hours: invalid time in `W1T08:99:00`: invalid minutes value"),
 		},
-	"when opening minutes invalid": {
-		openingHours:   "W1T08:99:00/W1T16:00:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid opening hours: invalid time in `W1T08:99:00`: invalid minutes value"),
+		"when closing string invalid": {
+			openingHours:   "W1T08:00:00/invalid",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid closing hours: invalid value `invalid`"),
 		},
-	"when closing string invalid": {
-		openingHours:   "W1T08:00:00/invalid",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid closing hours: invalid value `invalid`"),
+		"when closing weekday invalid": {
+			openingHours:   "W1T08:00:00/W9T16:00:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid closing hours: invalid workday in `W9T16:00:00`: expected to be between 1 (monday) and 7 (sunday)"),
 		},
-	"when closing weekday invalid": {
-		openingHours:   "W1T08:00:00/W9T16:00:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid closing hours: invalid workday in `W9T16:00:00`: expected to be between 1 (monday) and 7 (sunday)"),
+		"when closing hours invalid": {
+			openingHours:   "W1T08:00:00/W1T99:00:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid closing hours: invalid time in `W1T99:00:00`: invalid hours value"),
 		},
-	"when closing hours invalid": {
-		openingHours:   "W1T08:00:00/W1T99:00:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid closing hours: invalid time in `W1T99:00:00`: invalid hours value"),
+		"when closing minutes invalid": {
+			openingHours:   "W1T08:00:00/W1T16:99:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid closing hours: invalid time in `W1T16:99:00`: invalid minutes value"),
 		},
-	"when closing minutes invalid": {
-		openingHours:   "W1T08:00:00/W1T16:99:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid closing hours: invalid time in `W1T16:99:00`: invalid minutes value"),
-		},
-	"when closing time invalid": {
-		openingHours:   "W1T00:00:00/W7T24:01:00",
-		expectedResult: nil,
-		expectedError:  fmt.Errorf("invalid closing hours: invalid time in `W7T24:01:00`: invalid value"),
+		"when closing time invalid": {
+			openingHours:   "W1T00:00:00/W7T24:01:00",
+			expectedResult: nil,
+			expectedError:  fmt.Errorf("invalid closing hours: invalid time in `W7T24:01:00`: invalid value"),
 		},
 	}
 
@@ -506,6 +558,79 @@ func TestGetOCPIOpeningTimes(t *testing.T) {
 			ohs, _ := ParseOpeningHours(tt.openingHours)
 			result := GetOCPIOpeningTimes(ohs)
 			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestParseStringWeekdayToTimeWeekday(t *testing.T) {
+	tests := []struct {
+		input         string
+		expected      int
+		expectedError string
+	}{
+		{"monday", 1, ""},
+		{"tuesday", 2, ""},
+		{"wednesday", 3, ""},
+		{"thursday", 4, ""},
+		{"friday", 5, ""},
+		{"saturday", 6, ""},
+		{"sunday", 0, ""},
+		{"Monday", 1, ""},
+		{"TUESDAY", 2, ""},
+		{"friDAY", 5, ""},
+		{"", 0, "invalid weekday"},
+		{"funday", 0, "invalid weekday"},
+		{"mon", 0, "invalid weekday"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result, err := ParseStringWeekdayToTimeWeekday(tt.input)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, int(result))
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestParseMinutesSinceMidnight(t *testing.T) {
+	tests := []struct {
+		hourStr        string
+		minuteStr      string
+		expectedResult int
+		expectedError  string
+	}{
+		{"00", "00", 0, ""},
+		{"08", "30", 510, ""},
+		{"23", "59", 1439, ""},
+		{"24", "00", 1440, ""},
+		{"24", "01", 0, "invalid value"},
+		{"-1", "00", 0, "invalid hours value"},
+		{"25", "00", 0, "invalid hours value"},
+		{"12", "-1", 0, "invalid minutes value"},
+		{"12", "60", 0, "invalid minutes value"},
+		{"aa", "00", 0, "invalid hours value"},
+		{"12", "bb", 0, "invalid minutes value"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%s:%s", tt.hourStr, tt.minuteStr), func(t *testing.T) {
+			t.Parallel()
+			result, err := ParseMinutesSinceMidnight(tt.hourStr, tt.minuteStr)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
 		})
 	}
 }

--- a/openinghours_test.go
+++ b/openinghours_test.go
@@ -577,10 +577,9 @@ func TestParseStringWeekdayToTimeWeekday(t *testing.T) {
 		{"sunday", 0, ""},
 		{"Monday", 1, ""},
 		{"TUESDAY", 2, ""},
-		{"friDAY", 5, ""},
-		{"", 0, "invalid weekday"},
-		{"funday", 0, "invalid weekday"},
-		{"mon", 0, "invalid weekday"},
+		{"fri", 5, ""},
+		{"", -1, "invalid weekday"},
+		{"funday", -1, "invalid weekday"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adding three helper methods that will help reduce redundancy in other projects that use OpeningHours:
- Transform a slice of `OpeningHours` into a string (to then save in the db)
- Parse a weekday from a string to a `time.Weekday` value (that can be used as an int when building `OpeningHours`)
- Make the `ParseMinutesSinceMidnight` public to be used when transforming a time string value into `OpeningHours`.