### PR TITLE
add FreeForm hours conversion

### DIFF
--- a/openinghours.go
+++ b/openinghours.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // OpeningHours contains an opening and closing times within a given week. The
@@ -123,6 +124,647 @@ func ParseOpeningHours(v string) ([]OpeningHours, error) {
 	}
 
 	return ohs, nil
+}
+
+// freeformParser attempts to parse a free-form, human-written opening hours string. It returns
+// the parsed OpeningHours and true if the string matched its format, or false if the string
+// doesn't match, so that ParseFreeformOpeningHours can try the next parser in the list.
+type freeformParser func(string) ([]OpeningHours, bool, error)
+
+// freeformParsers is the list of supported free-form string formats, tried in order by
+// ParseFreeformOpeningHours. Add new formats by appending a parser here.
+var freeformParsers = []freeformParser{
+	parseTwentyFourSevenDaily,
+	parseMultiDaySegments,
+	parseDailyRange,
+}
+
+// parentheticalRegexp matches a parenthetical aside, eg. "(May-Sept)" or "(Sunday hours in winter
+// only)". These are treated as unstructured notes and stripped before parsing, the same way
+// free-text clauses like "for library visitors" are ignored.
+var parentheticalRegexp = regexp.MustCompile(`\([^)]*\)`)
+
+// ParseFreeformOpeningHours converts a free-form, human-written opening hours string (e.g.
+// "9am-9pm") into a []OpeningHours, trying each parser in freeformParsers in turn and returning
+// the result of the first one that matches. Parenthetical asides (eg. "(May-Sept)") are stripped
+// before parsing.
+func ParseFreeformOpeningHours(input string) ([]OpeningHours, error) {
+	trimmed := strings.TrimSpace(parentheticalRegexp.ReplaceAllString(input, ""))
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty opening hours string")
+	}
+
+	for _, parse := range freeformParsers {
+		ohs, ok, err := parse(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return ohs, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unrecognized opening hours format: %q", input)
+}
+
+// FreeformOpeningHoursToISOString converts a free-form opening hours string (e.g. "9am-9pm")
+// directly into its ISO-like string representation, as produced by OpeningHoursSliceToString.
+func FreeformOpeningHoursToISOString(input string) (string, error) {
+	ohs, err := ParseFreeformOpeningHours(input)
+	if err != nil {
+		return "", err
+	}
+
+	return OpeningHoursSliceToString(ohs), nil
+}
+
+var twentyFourSevenDailyRegexp = regexp.MustCompile(`(?i)^24\s*(?:hours?\s*daily|/\s*7)$`)
+
+// parseTwentyFourSevenDaily matches a string like "24 hours daily", "24 Hours Daily" or "24/7",
+// meaning the amenity is open every hour of every day of the week.
+func parseTwentyFourSevenDaily(input string) ([]OpeningHours, bool, error) {
+	if !twentyFourSevenDailyRegexp.MatchString(input) {
+		return nil, false, nil
+	}
+
+	return []OpeningHours{TwentyFourSevenOH}, true, nil
+}
+
+// weekdayAbbreviations maps the various abbreviated forms of a weekday name, as commonly found in
+// human-written opening hours (eg. "M", "Th", "Mon", "Sat"), to their RFC 3339 weekday number. A
+// bare "T" always means Tuesday, since Thursday is conventionally written out as "Th" in this
+// abbreviation style, leaving "T" unambiguous in practice.
+var weekdayAbbreviations = map[string]int{
+	"m":         1,
+	"mon":       1,
+	"monday":    1,
+	"t":         2,
+	"tu":        2,
+	"tue":       2,
+	"tues":      2,
+	"tuesday":   2,
+	"w":         3,
+	"wed":       3,
+	"wednesday": 3,
+	"th":        4,
+	"thu":       4,
+	"thur":      4,
+	"thurs":     4,
+	"thursday":  4,
+	"f":         5,
+	"fri":       5,
+	"friday":    5,
+	"sa":        6,
+	"sat":       6,
+	"saturday":  6,
+	"su":        7,
+	"sun":       7,
+	"sunday":    7,
+}
+
+// parseWeekdayAbbreviation converts an abbreviated weekday string (see weekdayAbbreviations) into
+// its RFC 3339 weekday number.
+func parseWeekdayAbbreviation(v string) (int, error) {
+	weekday, ok := weekdayAbbreviations[strings.ToLower(v)]
+	if !ok {
+		return 0, fmt.Errorf("invalid weekday abbreviation: %q", v)
+	}
+
+	return weekday, nil
+}
+
+// expandWeekdayRange returns every weekday number from `from` to `to`, inclusive, wrapping around
+// the week (eg. 6 (saturday) to 1 (monday) => [6, 7, 1]) if `to` comes before `from`.
+func expandWeekdayRange(from, to int) []int {
+	weekdays := []int{from}
+	for weekdays[len(weekdays)-1] != to {
+		next := weekdays[len(weekdays)-1]
+		setNextDay(&next)
+		weekdays = append(weekdays, next)
+	}
+
+	return weekdays
+}
+
+// daySegmentRegexp matches a single "<time range> <day spec>" clause, eg. "9am-9pm M-Th",
+// "9am-6pm F-Sat", "1pm-5pm Sun", "10am-5pm daily", "12pm-5pm, Mon-Sat" (a comma is accepted in
+// place of, or alongside, the whitespace between the time range and the day spec), "5am to 10pm
+// daily" (the word "to" is accepted as an alternative to the hyphen), "9-5pm Sat" (the opening
+// time's meridiem is optional and defaults to "am" when omitted - the closing time's meridiem is
+// still required) or "11am-6pm W-F and Sun" / "10am-6pm M & W" (a day spec may itself be a
+// ","/"and"/"&"-joined list of days or day ranges). The day spec is captured permissively
+// (anything at all) because resolveDaySpec knows how to recover a valid day spec from a trailing
+// free-text note glued onto it without a proper separator (eg. "M-F daily", "daily for guests").
+var daySegmentRegexp = regexp.MustCompile(`(?i)^(\d{1,2})(?::([0-5][0-9]))?(?:\s*(am|pm))?(?:\s*-\s*|\s+to\s+)(\d{1,2})(?::([0-5][0-9]))?\s*(am|pm)[,\s]+(.+)$`)
+
+// daySpecSeparatorRegexp splits a day spec into its individual day tokens or day ranges, eg.
+// "W-F and Sun" splits into ["W-F", "Sun"], "Mon, Wed and Fri" splits into ["Mon", "Wed", "Fri"],
+// and "M & W" splits into ["M", "W"].
+var daySpecSeparatorRegexp = regexp.MustCompile(`(?i)\s*,\s*|\s+and\s+|\s*&\s*`)
+
+// hasWordPrefix reports whether runes begins with word, case-insensitively, as a whole word (ie.
+// not immediately followed by another letter, so "closed" matches but "closedown" wouldn't).
+func hasWordPrefix(runes []rune, word string) bool {
+	if len(runes) < len(word) || !strings.EqualFold(string(runes[:len(word)]), word) {
+		return false
+	}
+
+	return len(runes) == len(word) || !unicode.IsLetter(runes[len(word)])
+}
+
+// splitOnComma splits a string on commas, but only when a comma is followed (after any
+// whitespace) by a digit - the start of a new time range - or by the word "closed" - the start of
+// a new exclusion clause, eg. "closed Sun". A comma directly between a time range and its own day
+// spec (eg. "12pm-5pm, Mon-Sat") is left alone, so daySegmentRegexp can match it as one clause.
+// RE2 (Go's regexp package) has no lookahead, so this can't be expressed as a single regexp.
+func splitOnComma(input string) []string {
+	runes := []rune(input)
+
+	var segments []string
+	start := 0
+	for i, r := range runes {
+		if r != ',' {
+			continue
+		}
+
+		j := i + 1
+		for j < len(runes) && unicode.IsSpace(runes[j]) {
+			j++
+		}
+		if j < len(runes) && (unicode.IsDigit(runes[j]) || hasWordPrefix(runes[j:], "closed")) {
+			segments = append(segments, string(runes[start:i]))
+			start = i + 1
+		}
+	}
+	segments = append(segments, string(runes[start:]))
+
+	return segments
+}
+
+// allWeekdays are the RFC 3339 weekday numbers for every day of the week, monday through sunday.
+var allWeekdays = []int{1, 2, 3, 4, 5, 6, 7}
+
+// weekdaysMonToFri are the RFC 3339 weekday numbers for the "weekdays" keyword.
+var weekdaysMonToFri = []int{1, 2, 3, 4, 5}
+
+// resolveDaySpec resolves a day spec (the day portion of a daySegmentRegexp match) into the
+// weekday numbers it covers, or false if nothing in it resolves to a recognizable day at all. A
+// day spec is the keyword "daily"/"every day" (every day of the week), "weekdays"/"weekday"
+// (monday through friday), or one or more day tokens/day ranges (eg. "Mon", "W-F") joined by
+// ","/"and"/"&" (eg. "W-F and Sun", "Mon, Wed and Fri", "M & W").
+//
+// Each token is resolved independently via resolveDaySpecToken, which progressively drops
+// trailing words and retries if a token doesn't resolve as-is. This recovers the recoverable days
+// from a free-text note glued onto (or alongside) a valid day spec with no clean separator, eg.:
+//   - "M-F daily" and "daily for guests" (a single token, with no list separator at all) recover
+//     "M-F" and "daily" respectively;
+//   - "Sat, for client use only" and "M-F, for employee use only" (a real day followed by a
+//     comma-glued note) recover "Sat" and "M-F", silently dropping the unresolvable second token;
+//   - "daily for staff, students and faculty with a permit" recovers "daily" from its first
+//     token, dropping "students" and "faculty with a permit".
+//
+// A token that never resolves to anything, even after trimming down to a single word (eg. "Xyz",
+// "students"), is silently dropped rather than treated as an error: free-text notes are common and
+// varied enough that erroring on an unrecognized word is more likely to reject a legitimate note
+// than to catch a genuine typo in a day list. If nothing in the whole day spec resolves to any
+// weekday at all, ok is false, so the caller can treat the whole clause as unmatched, the same as
+// if it never looked like a day spec in the first place.
+//
+// Weekdays are returned in first-seen order, deduplicated, so an accidental overlap between
+// tokens doesn't produce duplicate OpeningHours entries.
+func resolveDaySpec(daySpec string) ([]int, bool) {
+	var weekdays []int
+	seen := make(map[int]bool, 7)
+	for _, token := range daySpecSeparatorRegexp.Split(daySpec, -1) {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+
+		tokenWeekdays, ok := resolveDaySpecToken(token)
+		if !ok {
+			continue
+		}
+
+		for _, weekday := range tokenWeekdays {
+			if seen[weekday] {
+				continue
+			}
+
+			seen[weekday] = true
+			weekdays = append(weekdays, weekday)
+		}
+	}
+
+	return weekdays, len(weekdays) > 0
+}
+
+// resolveDaySpecToken resolves one token - a single day, day range, or recognized keyword - into
+// the weekday numbers it covers, progressively dropping trailing words and retrying if it doesn't
+// resolve as-is (see resolveDaySpec).
+func resolveDaySpecToken(token string) ([]int, bool) {
+	if weekdays, ok := resolveSingleDaySpec(token); ok {
+		return weekdays, true
+	}
+
+	words := strings.Fields(token)
+	for n := len(words) - 1; n >= 1; n-- {
+		if weekdays, ok := resolveSingleDaySpec(strings.Join(words[:n], " ")); ok {
+			return weekdays, true
+		}
+	}
+
+	return nil, false
+}
+
+// resolveSingleDaySpec resolves one day token, day range, or recognized keyword ("daily", "every
+// day", "weekdays", "weekday") into the weekday numbers it covers. ok is false if s doesn't
+// resolve to anything recognizable.
+func resolveSingleDaySpec(s string) ([]int, bool) {
+	switch {
+	case strings.EqualFold(s, "daily"), strings.EqualFold(s, "every day"):
+		return allWeekdays, true
+	case strings.EqualFold(s, "weekdays"), strings.EqualFold(s, "weekday"):
+		return weekdaysMonToFri, true
+	}
+
+	fromDay, toDay, err := parseDayOrDayRange(s)
+	if err != nil {
+		return nil, false
+	}
+
+	return expandWeekdayRange(fromDay, toDay), true
+}
+
+// parseDayOrDayRange parses a single day token (eg. "Sat") or day range (eg. "M-Th") into its
+// start and end weekday numbers. A single day's start and end are the same weekday. "S-S" is
+// special-cased to mean "Saturday-Sunday", a common shorthand; a bare "S" outside of that idiom is
+// genuinely ambiguous between Saturday and Sunday and isn't otherwise supported.
+func parseDayOrDayRange(token string) (int, int, error) {
+	if strings.EqualFold(token, "s-s") {
+		return 6, 7, nil
+	}
+
+	parts := strings.SplitN(token, "-", 2)
+
+	fromDay, err := parseWeekdayAbbreviation(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if len(parts) == 1 {
+		return fromDay, fromDay, nil
+	}
+
+	toDay, err := parseWeekdayAbbreviation(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return fromDay, toDay, nil
+}
+
+// parseTimeRangeMinutes parses the "<time>-<time>" (or "<time> to <time>") prefix shared by
+// dailyRangeRegexp and daySegmentRegexp (whose first six capture groups have the same shape) into
+// opening and closing minutes since midnight. overnight is true when the closing time is earlier
+// in the day than the opening time, meaning the range spans past midnight into the next day (eg.
+// "10pm-6am" opens at 22:00 and closes at 06:00 the following day).
+func parseTimeRangeMinutes(matches []string) (openMinutes, closeMinutes int, overnight bool, err error) {
+	openMinutes, err = parse12HourTime(matches[1], matches[2], matches[3])
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("invalid opening time in %q: %s", matches[0], err)
+	}
+
+	closeMinutes, err = parse12HourClosingTime(matches[4], matches[5], matches[6])
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("invalid closing time in %q: %s", matches[0], err)
+	}
+
+	if closeMinutes == openMinutes {
+		return 0, 0, false, fmt.Errorf("closing time must be after opening time in %q", matches[0])
+	}
+
+	return openMinutes, closeMinutes, closeMinutes < openMinutes, nil
+}
+
+// buildOpeningHour builds a single OpeningHours entry for the given weekday and time window,
+// rolling the closing weekday forward to the next day when overnight is true.
+func buildOpeningHour(weekday, openMinutes, closeMinutes int, overnight bool) OpeningHours {
+	closeWeekday := weekday
+	if overnight {
+		setNextDay(&closeWeekday)
+	}
+
+	return OpeningHours{
+		Open:  &TimeInWeek{Weekday: weekday, MinutesSinceMidnight: openMinutes},
+		Close: &TimeInWeek{Weekday: closeWeekday, MinutesSinceMidnight: closeMinutes},
+	}
+}
+
+// buildOpeningHoursForWeekdays builds one OpeningHours entry per weekday for a single time
+// window.
+func buildOpeningHoursForWeekdays(weekdays []int, openMinutes, closeMinutes int, overnight bool) []OpeningHours {
+	ohs := make([]OpeningHours, 0, len(weekdays))
+	for _, weekday := range weekdays {
+		ohs = append(ohs, buildOpeningHour(weekday, openMinutes, closeMinutes, overnight))
+	}
+
+	return ohs
+}
+
+// buildEveryDayOpeningHours builds one OpeningHours entry per weekday from a bare "<time>-<time>"
+// match (from dailyRangeRegexp).
+func buildEveryDayOpeningHours(matches []string) ([]OpeningHours, error) {
+	openMinutes, closeMinutes, overnight, err := parseTimeRangeMinutes(matches)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildOpeningHoursForWeekdays(allWeekdays, openMinutes, closeMinutes, overnight), nil
+}
+
+// allBareTimeRanges reports whether every segment is a bare time range with no day spec of its
+// own (eg. "12am-7am"), as matched by dailyRangeRegexp. An empty list reports false, since there's
+// nothing to share a trailing day spec with.
+func allBareTimeRanges(segments []string) bool {
+	if len(segments) == 0 {
+		return false
+	}
+
+	for _, segment := range segments {
+		if !dailyRangeRegexp.MatchString(segment) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// timeWindow is an opening/closing time pair, in minutes since midnight, plus whether it spans
+// past midnight into the next day.
+type timeWindow struct {
+	openMinutes, closeMinutes int
+	overnight                 bool
+}
+
+// parseSharedDaySpecGroup parses a list of segments whose final segment carries the only day
+// spec, which applies to every time range in the list, eg. ["12am-7am", "9am-5:30pm",
+// "7:30pm-12am daily"] (all three windows apply daily). Every segment but the last must match
+// dailyRangeRegexp, and the last must match daySegmentRegexp.
+func parseSharedDaySpecGroup(segments []string) ([]OpeningHours, error) {
+	lastMatches := daySegmentRegexp.FindStringSubmatch(segments[len(segments)-1])
+
+	weekdays, ok := resolveDaySpec(lastMatches[7])
+	if !ok {
+		return nil, nil
+	}
+
+	windows := make([]timeWindow, 0, len(segments))
+	for _, segment := range segments[:len(segments)-1] {
+		openMinutes, closeMinutes, overnight, err := parseTimeRangeMinutes(dailyRangeRegexp.FindStringSubmatch(segment))
+		if err != nil {
+			return nil, err
+		}
+
+		windows = append(windows, timeWindow{openMinutes, closeMinutes, overnight})
+	}
+
+	lastOpenMinutes, lastCloseMinutes, lastOvernight, err := parseTimeRangeMinutes(lastMatches)
+	if err != nil {
+		return nil, err
+	}
+	windows = append(windows, timeWindow{lastOpenMinutes, lastCloseMinutes, lastOvernight})
+
+	var ohs []OpeningHours
+	for _, weekday := range weekdays {
+		for _, w := range windows {
+			ohs = append(ohs, buildOpeningHour(weekday, w.openMinutes, w.closeMinutes, w.overnight))
+		}
+	}
+
+	return ohs, nil
+}
+
+// windowSeparatorRegexp splits a segment on " and " or "&" when it's being used to join multiple
+// bare time ranges that share one trailing day spec, eg. "8am-12pm and 1pm-5pm M-F" or
+// "6:30am-6pm & 8pm-10pm daily".
+var windowSeparatorRegexp = regexp.MustCompile(`(?i)\s+and\s+|\s*&\s*`)
+
+// parseAndSharedWindowSegment matches a segment made of two or more "and"/"&"-joined time ranges
+// that share a single trailing day spec, eg. "8am-12pm and 1pm-5pm M-F" or "6:30am-6pm & 8pm-10pm
+// daily". It reports matched=false (without error) if the segment doesn't look like this pattern -
+// eg. a single time range whose day spec happens to contain "and"/"&" itself, like "11am-6pm W-F
+// and Sun" or "10am-6pm M & W" - so the caller can fall back to treating it as an ordinary single
+// "<time range> <day spec>" clause.
+func parseAndSharedWindowSegment(segment string) ([]OpeningHours, bool, error) {
+	parts := windowSeparatorRegexp.Split(segment, -1)
+	if len(parts) < 2 || !daySegmentRegexp.MatchString(parts[len(parts)-1]) || !allBareTimeRanges(parts[:len(parts)-1]) {
+		return nil, false, nil
+	}
+
+	ohs, err := parseSharedDaySpecGroup(parts)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return ohs, true, nil
+}
+
+// twentyFourHoursDaySpecRegexp matches "24 hours <day spec>" or "24 hour <day spec>", eg. "24
+// hours Sat-Sun", meaning the amenity is open the full day (00:00-24:00) on the given days. This
+// is distinct from parseTwentyFourSevenDaily, which matches the keyword applied to the *whole*
+// input string; this one is a single clause that can sit alongside other clauses in the same
+// string, eg. "3pm-7:45am M-F, 24 hours Sat-Sun".
+var twentyFourHoursDaySpecRegexp = regexp.MustCompile(`(?i)^24\s*hours?\s+(.+)$`)
+
+// parseTwentyFourHoursDaySpecSegment matches a "24 hours <day spec>" segment.
+func parseTwentyFourHoursDaySpecSegment(segment string) ([]OpeningHours, bool, error) {
+	matches := twentyFourHoursDaySpecRegexp.FindStringSubmatch(segment)
+	if matches == nil {
+		return nil, false, nil
+	}
+
+	weekdays, ok := resolveDaySpec(matches[1])
+	if !ok {
+		return nil, false, nil
+	}
+
+	return buildOpeningHoursForWeekdays(weekdays, 0, 1440, false), true, nil
+}
+
+// parseSingleDaySegment matches an ordinary single "<time range> <day spec>" clause.
+func parseSingleDaySegment(segment string) ([]OpeningHours, bool, error) {
+	matches := daySegmentRegexp.FindStringSubmatch(segment)
+	if matches == nil {
+		return nil, false, nil
+	}
+
+	openMinutes, closeMinutes, overnight, err := parseTimeRangeMinutes(matches)
+	if err != nil {
+		return nil, true, err
+	}
+
+	weekdays, ok := resolveDaySpec(matches[7])
+	if !ok {
+		return nil, false, nil
+	}
+
+	return buildOpeningHoursForWeekdays(weekdays, openMinutes, closeMinutes, overnight), true, nil
+}
+
+// segmentParsers is the list of patterns tried, in order, for each individual comma-separated
+// segment within a parseDaySegmentGroup group.
+var segmentParsers = []func(string) ([]OpeningHours, bool, error){
+	parseTwentyFourHoursDaySpecSegment,
+	parseAndSharedWindowSegment,
+	parseSingleDaySegment,
+}
+
+// parseDaySegmentGroup parses one semicolon-delimited group of one or more comma-separated
+// segments. Normally each segment carries its own day spec, eg. "9am-9pm M-Th, 9am-6pm F". But:
+//   - when a group's last segment is the only one with a day spec, and every segment before it is
+//     a bare time range (eg. "12am-7am, 9am-5:30pm, 7:30pm-12am daily"), that day spec is shared
+//     across all of them;
+//   - a lone segment with no day spec at all, but a valid bare time range (eg. "8am-5pm" with
+//     nothing else in the group), is treated as applying every day, same as parseDailyRange;
+//   - "24 hours <day spec>" and "<time> and <time> ... <day spec>" segments are recognized by
+//     segmentParsers.
+//
+// Segments that match none of these, such as free-text notes ("for library visitors", "2 hour
+// charging limit") or explicit exclusions ("closed Sun"), are ignored.
+func parseDaySegmentGroup(group string) ([]OpeningHours, error) {
+	var trimmed []string
+	for _, segment := range splitOnComma(group) {
+		if segment = strings.TrimSpace(segment); segment != "" {
+			trimmed = append(trimmed, segment)
+		}
+	}
+
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	if len(trimmed) > 1 && daySegmentRegexp.MatchString(trimmed[len(trimmed)-1]) && allBareTimeRanges(trimmed[:len(trimmed)-1]) {
+		return parseSharedDaySpecGroup(trimmed)
+	}
+
+	if len(trimmed) == 1 {
+		if matches := dailyRangeRegexp.FindStringSubmatch(trimmed[0]); matches != nil {
+			return buildEveryDayOpeningHours(matches)
+		}
+	}
+
+	var ohs []OpeningHours
+	for _, segment := range trimmed {
+		for _, parse := range segmentParsers {
+			segmentOhs, matched, err := parse(segment)
+			if err != nil {
+				return nil, err
+			}
+			if matched {
+				ohs = append(ohs, segmentOhs...)
+				break
+			}
+		}
+	}
+
+	return ohs, nil
+}
+
+// parseMultiDaySegments matches opening-hours strings made up of one or more semicolon-separated
+// groups, eg. "9am-9pm M-Th, 9am-6pm F, 9am-5pm Sat, 1pm-5pm Sun", "10am-5pm daily",
+// "12pm-5pm, Mon-Sat" or "12am-7am, 9am-5:30pm, 7:30pm-12am daily". The string is considered a
+// match as long as at least one group parses successfully.
+func parseMultiDaySegments(input string) ([]OpeningHours, bool, error) {
+	var ohs []OpeningHours
+	for _, group := range strings.Split(input, ";") {
+		groupOhs, err := parseDaySegmentGroup(group)
+		if err != nil {
+			return nil, true, err
+		}
+
+		ohs = append(ohs, groupOhs...)
+	}
+
+	if len(ohs) == 0 {
+		return nil, false, nil
+	}
+
+	return ohs, true, nil
+}
+
+var dailyRangeRegexp = regexp.MustCompile(`(?i)^(\d{1,2})(?::([0-5][0-9]))?(?:\s*(am|pm))?(?:\s*-\s*|\s+to\s+)(\d{1,2})(?::([0-5][0-9]))?\s*(am|pm)$`)
+
+// parseDailyRange matches a single 12-hour time range applied to every day of the week, e.g.
+// "9am-9pm", "9:30am - 5:00pm" or "5am to 10pm", producing seven OpeningHours, one per weekday.
+func parseDailyRange(input string) ([]OpeningHours, bool, error) {
+	matches := dailyRangeRegexp.FindStringSubmatch(input)
+	if matches == nil {
+		return nil, false, nil
+	}
+
+	ohs, err := buildEveryDayOpeningHours(matches)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return ohs, true, nil
+}
+
+// parse12HourTime parses a 12-hour clock time, given as separate hour, minute and meridiem
+// ("am"/"pm") strings, into minutes since midnight. minuteStr may be empty, in which case the
+// minutes are assumed to be zero. meridiem may also be empty (eg. an opening time written as
+// "9-5pm", where only the closing time carries "pm"), in which case it's assumed to be "am".
+func parse12HourTime(hourStr, minuteStr, meridiem string) (int, error) {
+	hour, err := strconv.Atoi(hourStr)
+	if err != nil || hour < 1 || hour > 12 {
+		return 0, fmt.Errorf("invalid hour value")
+	}
+
+	minute := 0
+	if minuteStr != "" {
+		minute, err = strconv.Atoi(minuteStr)
+		if err != nil || minute < 0 || minute > 59 {
+			return 0, fmt.Errorf("invalid minute value")
+		}
+	}
+
+	if meridiem == "" {
+		meridiem = "am"
+	}
+
+	switch strings.ToLower(meridiem) {
+	case "am":
+		if hour == 12 {
+			hour = 0
+		}
+	case "pm":
+		if hour != 12 {
+			hour += 12
+		}
+	default:
+		return 0, fmt.Errorf("invalid meridiem value")
+	}
+
+	return hour*60 + minute, nil
+}
+
+// parse12HourClosingTime parses a 12-hour clock closing time the same way as parse12HourTime,
+// except that "12am" is treated as the end of the day (24:00, ie. 1440 minutes since midnight)
+// rather than its start. As an opening time, "12am" means midnight at the start of the day (eg.
+// "12am-8am" opens at 00:00); as a closing time in the same day/day range, it conventionally means
+// open until the end of that day (eg. "10am-12am" closes at 24:00, not 00:00).
+func parse12HourClosingTime(hourStr, minuteStr, meridiem string) (int, error) {
+	minutes, err := parse12HourTime(hourStr, minuteStr, meridiem)
+	if err != nil {
+		return 0, err
+	}
+
+	if minutes == 0 && strings.EqualFold(meridiem, "am") {
+		return 1440, nil
+	}
+
+	return minutes, nil
 }
 
 type TimeRange struct {

--- a/openinghours_test.go
+++ b/openinghours_test.go
@@ -598,6 +598,582 @@ func TestParseStringWeekdayToTimeWeekday(t *testing.T) {
 	}
 }
 
+func TestParseFreeformOpeningHours(t *testing.T) {
+	dailyOpeningHours := func(open, close int) []OpeningHours {
+		ohs := make([]OpeningHours, 0, 7)
+		for weekday := 1; weekday <= 7; weekday++ {
+			ohs = append(ohs, OpeningHours{
+				Open:  &TimeInWeek{Weekday: weekday, MinutesSinceMidnight: open},
+				Close: &TimeInWeek{Weekday: weekday, MinutesSinceMidnight: close},
+			})
+		}
+		return ohs
+	}
+
+	dayOpeningHours := func(weekday, open, close int) OpeningHours {
+		return OpeningHours{
+			Open:  &TimeInWeek{Weekday: weekday, MinutesSinceMidnight: open},
+			Close: &TimeInWeek{Weekday: weekday, MinutesSinceMidnight: close},
+		}
+	}
+
+	overnightDayOpeningHours := func(weekday, open, close int) OpeningHours {
+		closeWeekday := weekday%7 + 1
+		return OpeningHours{
+			Open:  &TimeInWeek{Weekday: weekday, MinutesSinceMidnight: open},
+			Close: &TimeInWeek{Weekday: closeWeekday, MinutesSinceMidnight: close},
+		}
+	}
+
+	overnightDailyOpeningHours := func(open, close int) []OpeningHours {
+		ohs := make([]OpeningHours, 0, 7)
+		for weekday := 1; weekday <= 7; weekday++ {
+			ohs = append(ohs, overnightDayOpeningHours(weekday, open, close))
+		}
+		return ohs
+	}
+
+	tests := map[string]struct {
+		input          string
+		expectedResult []OpeningHours
+		expectedError  string
+	}{
+		"9am-9pm": {
+			input:          "9am-9pm",
+			expectedResult: dailyOpeningHours(540, 1260),
+		},
+		"24 hours daily": {
+			input:          "24 hours daily",
+			expectedResult: []OpeningHours{TwentyFourSevenOH},
+		},
+		"24 Hours Daily mixed case": {
+			input:          "24 Hours Daily",
+			expectedResult: []OpeningHours{TwentyFourSevenOH},
+		},
+		"24 hour daily singular": {
+			input:          "24 hour daily",
+			expectedResult: []OpeningHours{TwentyFourSevenOH},
+		},
+		"24hoursdaily no spaces": {
+			input:          "24hoursdaily",
+			expectedResult: []OpeningHours{TwentyFourSevenOH},
+		},
+		"24/7": {
+			input:          "24/7",
+			expectedResult: []OpeningHours{TwentyFourSevenOH},
+		},
+		"24 / 7 with spaces": {
+			input:          "24 / 7",
+			expectedResult: []OpeningHours{TwentyFourSevenOH},
+		},
+		"9am-9pm with spaces around dash": {
+			input:          "9am - 9pm",
+			expectedResult: dailyOpeningHours(540, 1260),
+		},
+		"9AM-9PM uppercase": {
+			input:          "9AM-9PM",
+			expectedResult: dailyOpeningHours(540, 1260),
+		},
+		"9:30am-5:00pm with minutes": {
+			input:          "9:30am-5:00pm",
+			expectedResult: dailyOpeningHours(570, 1020),
+		},
+		"12am-12pm midnight to noon": {
+			input:          "12am-12pm",
+			expectedResult: dailyOpeningHours(0, 720),
+		},
+		"leading and trailing whitespace": {
+			input:          "  9am-9pm  ",
+			expectedResult: dailyOpeningHours(540, 1260),
+		},
+		"empty string": {
+			input:         "",
+			expectedError: "empty opening hours string",
+		},
+		"unrecognized format": {
+			input:         "open all day",
+			expectedError: `unrecognized opening hours format: "open all day"`,
+		},
+		"missing opening meridiem defaults to am": {
+			input:          "9-9pm",
+			expectedResult: dailyOpeningHours(540, 1260),
+		},
+		"closing time before opening time wraps to the next day": {
+			input:          "9pm-9am",
+			expectedResult: overnightDailyOpeningHours(1260, 540),
+		},
+		"closing time equal to opening time": {
+			input:         "9am-9am",
+			expectedError: `closing time must be after opening time in "9am-9am"`,
+		},
+		"invalid hour": {
+			input:         "13am-9pm",
+			expectedError: `invalid opening time in "13am-9pm": invalid hour value`,
+		},
+		"invalid minute": {
+			input:         "9:60am-9pm",
+			expectedError: `unrecognized opening hours format: "9:60am-9pm"`,
+		},
+		"12am closing time means end of day, not start of day": {
+			input:          "11am-12am",
+			expectedResult: dailyOpeningHours(660, 1440),
+		},
+		"12am opening time still means start of day": {
+			input:          "12am-8am",
+			expectedResult: dailyOpeningHours(0, 480),
+		},
+		"12am closing time end of day with a day range": {
+			input: "10am-12am M-Sat",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 600, 1440),
+				dayOpeningHours(2, 600, 1440),
+				dayOpeningHours(3, 600, 1440),
+				dayOpeningHours(4, 600, 1440),
+				dayOpeningHours(5, 600, 1440),
+				dayOpeningHours(6, 600, 1440),
+			},
+		},
+		"daily keyword applies to every weekday": {
+			input:          "10am-5pm daily",
+			expectedResult: dailyOpeningHours(600, 1020),
+		},
+		"daily keyword uppercase": {
+			input:          "10am-5pm DAILY",
+			expectedResult: dailyOpeningHours(600, 1020),
+		},
+		"daily keyword with trailing notes": {
+			input:          "10am-10pm daily; for guest use only; Drivers must bring their own J1772 cordset for Level 1 charging",
+			expectedResult: dailyOpeningHours(600, 1320),
+		},
+		"daily keyword with noon opening time": {
+			input:          "12pm-9pm daily",
+			expectedResult: dailyOpeningHours(720, 1260),
+		},
+		"trailing parenthetical aside is ignored": {
+			input: "10am-5pm Wed-Sun (May-Sept)",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(3, 600, 1020),
+				dayOpeningHours(4, 600, 1020),
+				dayOpeningHours(5, 600, 1020),
+				dayOpeningHours(6, 600, 1020),
+				dayOpeningHours(7, 600, 1020),
+			},
+		},
+		"parenthetical aside on the last of several clauses is ignored": {
+			input: "10am-8pm M-Th, 10am-6pm F, 10am-5pm Sat, 1pm-5pm Sun (Sunday hours in winter only)",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 600, 1200),
+				dayOpeningHours(2, 600, 1200),
+				dayOpeningHours(3, 600, 1200),
+				dayOpeningHours(4, 600, 1200),
+				dayOpeningHours(5, 600, 1080),
+				dayOpeningHours(6, 600, 1020),
+				dayOpeningHours(7, 780, 1020),
+			},
+		},
+		"comma may separate a time range from its day spec": {
+			input: "12pm-5pm, Mon-Sat; ask for key card at reception",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 720, 1020),
+				dayOpeningHours(2, 720, 1020),
+				dayOpeningHours(3, 720, 1020),
+				dayOpeningHours(4, 720, 1020),
+				dayOpeningHours(5, 720, 1020),
+				dayOpeningHours(6, 720, 1020),
+			},
+		},
+		"day spec joining a range and a single day with and": {
+			input: "11am-6pm W-F and Sun, 11am-8pm Sat; Winery customers only",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(3, 660, 1080),
+				dayOpeningHours(4, 660, 1080),
+				dayOpeningHours(5, 660, 1080),
+				dayOpeningHours(7, 660, 1080),
+				dayOpeningHours(6, 660, 1200),
+			},
+		},
+		"day spec joining single days with comma and and": {
+			input: "9am-5pm Mon, Wed and Fri",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1020),
+				dayOpeningHours(3, 540, 1020),
+				dayOpeningHours(5, 540, 1020),
+			},
+		},
+		"unresolvable token within an and-joined day spec is dropped, not an error": {
+			input: "9am-5pm Mon and Xyz",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1020),
+			},
+		},
+		"day spec joining days with ampersand": {
+			input: "10am-6pm M & W, 10am-8pm T & Th, 10am-5pm F-Sat",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 600, 1080),
+				dayOpeningHours(3, 600, 1080),
+				dayOpeningHours(2, 600, 1200),
+				dayOpeningHours(4, 600, 1200),
+				dayOpeningHours(5, 600, 1020),
+				dayOpeningHours(6, 600, 1020),
+			},
+		},
+		"multiple bare time windows share a single trailing daily keyword": {
+			input: "12am-7am, 9am-5:30pm, 7:30pm-12am daily",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 0, 420), dayOpeningHours(1, 540, 1050), dayOpeningHours(1, 1170, 1440),
+				dayOpeningHours(2, 0, 420), dayOpeningHours(2, 540, 1050), dayOpeningHours(2, 1170, 1440),
+				dayOpeningHours(3, 0, 420), dayOpeningHours(3, 540, 1050), dayOpeningHours(3, 1170, 1440),
+				dayOpeningHours(4, 0, 420), dayOpeningHours(4, 540, 1050), dayOpeningHours(4, 1170, 1440),
+				dayOpeningHours(5, 0, 420), dayOpeningHours(5, 540, 1050), dayOpeningHours(5, 1170, 1440),
+				dayOpeningHours(6, 0, 420), dayOpeningHours(6, 540, 1050), dayOpeningHours(6, 1170, 1440),
+				dayOpeningHours(7, 0, 420), dayOpeningHours(7, 540, 1050), dayOpeningHours(7, 1170, 1440),
+			},
+		},
+		"multiple bare time windows share a single trailing day range": {
+			input: "9am-12pm, 1pm-5pm Sat-Sun",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(6, 540, 720), dayOpeningHours(6, 780, 1020),
+				dayOpeningHours(7, 540, 720), dayOpeningHours(7, 780, 1020),
+			},
+		},
+		"overnight range with an explicit weekday range wraps to the next day": {
+			input: "3pm-7:45am M-F",
+			expectedResult: []OpeningHours{
+				overnightDayOpeningHours(1, 900, 465),
+				overnightDayOpeningHours(2, 900, 465),
+				overnightDayOpeningHours(3, 900, 465),
+				overnightDayOpeningHours(4, 900, 465),
+				overnightDayOpeningHours(5, 900, 465),
+			},
+		},
+		"overnight weekday range combined with a 24-hours weekend clause": {
+			input: "3pm-7:45am M-F, 24 hours Sat-Sun",
+			expectedResult: []OpeningHours{
+				overnightDayOpeningHours(1, 900, 465),
+				overnightDayOpeningHours(2, 900, 465),
+				overnightDayOpeningHours(3, 900, 465),
+				overnightDayOpeningHours(4, 900, 465),
+				overnightDayOpeningHours(5, 900, 465),
+				dayOpeningHours(6, 0, 1440),
+				dayOpeningHours(7, 0, 1440),
+			},
+		},
+		"24 hours day spec on its own": {
+			input: "24 hours Sat-Sun",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(6, 0, 1440),
+				dayOpeningHours(7, 0, 1440),
+			},
+		},
+		"to used as a synonym for the time-range hyphen": {
+			input:          "5am to 10pm daily",
+			expectedResult: dailyOpeningHours(300, 1320),
+		},
+		"to combined with an overnight range and a dropped note": {
+			input:          "6am to 2am; pay lot",
+			expectedResult: overnightDailyOpeningHours(360, 120),
+		},
+		"missing opening meridiem with an explicit day defaults to am": {
+			input: "9-5pm Sat",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(6, 540, 1020),
+			},
+		},
+		"missing opening meridiem combined with to and a separate daily clause": {
+			input:          "4:30 to 7am; daily",
+			expectedResult: dailyOpeningHours(270, 420),
+		},
+		"ampersand joining two time windows that share a trailing daily keyword": {
+			input: "6:30am-6pm & 8pm-10pm daily; see Pro Shop or Restaurant attendant for access",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 390, 1080), dayOpeningHours(1, 1200, 1320),
+				dayOpeningHours(2, 390, 1080), dayOpeningHours(2, 1200, 1320),
+				dayOpeningHours(3, 390, 1080), dayOpeningHours(3, 1200, 1320),
+				dayOpeningHours(4, 390, 1080), dayOpeningHours(4, 1200, 1320),
+				dayOpeningHours(5, 390, 1080), dayOpeningHours(5, 1200, 1320),
+				dayOpeningHours(6, 390, 1080), dayOpeningHours(6, 1200, 1320),
+				dayOpeningHours(7, 390, 1080), dayOpeningHours(7, 1200, 1320),
+			},
+		},
+		"free-text note containing its own comma is dropped instead of erroring": {
+			input: "8:30am-5:30pm M-F, 9am-3pm Sat, for client use only",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 510, 1050),
+				dayOpeningHours(2, 510, 1050),
+				dayOpeningHours(3, 510, 1050),
+				dayOpeningHours(4, 510, 1050),
+				dayOpeningHours(5, 510, 1050),
+				dayOpeningHours(6, 540, 900),
+			},
+		},
+		"free-text note glued via a non-splitting comma after a day range": {
+			input: "8am-6pm M-F, for employee use only",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 480, 1080),
+				dayOpeningHours(2, 480, 1080),
+				dayOpeningHours(3, 480, 1080),
+				dayOpeningHours(4, 480, 1080),
+				dayOpeningHours(5, 480, 1080),
+			},
+		},
+		"redundant trailing daily keyword after an explicit day range is dropped": {
+			input: "9am-9pm M-F daily",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1260),
+				dayOpeningHours(2, 540, 1260),
+				dayOpeningHours(3, 540, 1260),
+				dayOpeningHours(4, 540, 1260),
+				dayOpeningHours(5, 540, 1260),
+			},
+		},
+		"free-text note glued directly onto daily with no separator": {
+			input:          "8am-11pm daily during the summer",
+			expectedResult: dailyOpeningHours(480, 1380),
+		},
+		"weekdays keyword": {
+			input: "8am-5pm weekdays; tenant use only",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 480, 1020),
+				dayOpeningHours(2, 480, 1020),
+				dayOpeningHours(3, 480, 1020),
+				dayOpeningHours(4, 480, 1020),
+				dayOpeningHours(5, 480, 1020),
+			},
+		},
+		"every day keyword": {
+			input:          "7am-11:59pm every day; first come, first served for permit holders, university vehicles, and public",
+			expectedResult: dailyOpeningHours(420, 1439),
+		},
+		"closed day dropped when glued onto a preceding day spec": {
+			input: "8am-5pm T-Sat, 12pm-5pm Sun, closed M",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(2, 480, 1020),
+				dayOpeningHours(3, 480, 1020),
+				dayOpeningHours(4, 480, 1020),
+				dayOpeningHours(5, 480, 1020),
+				dayOpeningHours(6, 480, 1020),
+				dayOpeningHours(7, 720, 1020),
+			},
+		},
+		"S-S means Saturday-Sunday": {
+			input: "7am - 10pm S-S, 6am - 10pm M-F",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(6, 420, 1320),
+				dayOpeningHours(7, 420, 1320),
+				dayOpeningHours(1, 360, 1320),
+				dayOpeningHours(2, 360, 1320),
+				dayOpeningHours(3, 360, 1320),
+				dayOpeningHours(4, 360, 1320),
+				dayOpeningHours(5, 360, 1320),
+			},
+		},
+		"and-joined time windows sharing a trailing day range": {
+			input: "8am-12pm and 1pm-5pm M-F; for guest use only",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 480, 720), dayOpeningHours(1, 780, 1020),
+				dayOpeningHours(2, 480, 720), dayOpeningHours(2, 780, 1020),
+				dayOpeningHours(3, 480, 720), dayOpeningHours(3, 780, 1020),
+				dayOpeningHours(4, 480, 720), dayOpeningHours(4, 780, 1020),
+				dayOpeningHours(5, 480, 720), dayOpeningHours(5, 780, 1020),
+			},
+		},
+		"bare time range with no day spec at all still applies daily when followed only by a note": {
+			input:          "9am-5pm; ask for office key at the front desk",
+			expectedResult: dailyOpeningHours(540, 1020),
+		},
+		"library hours with mixed single and multi-letter day abbreviations and notes": {
+			input: "9am-9pm M-Th, 9am-6pm F, 9am-5pm Sat, 1pm-5pm Sun; for library visitors; 2 hour charging limit",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1260),
+				dayOpeningHours(2, 540, 1260),
+				dayOpeningHours(3, 540, 1260),
+				dayOpeningHours(4, 540, 1260),
+				dayOpeningHours(5, 540, 1080),
+				dayOpeningHours(6, 540, 1020),
+				dayOpeningHours(7, 780, 1020),
+			},
+		},
+		"day ranges mixing single-letter and three-letter abbreviations": {
+			input: "9am-9pm M-Th, 9am-6pm F-Sat, 11am-5pm Sun",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1260),
+				dayOpeningHours(2, 540, 1260),
+				dayOpeningHours(3, 540, 1260),
+				dayOpeningHours(4, 540, 1260),
+				dayOpeningHours(5, 540, 1080),
+				dayOpeningHours(6, 540, 1080),
+				dayOpeningHours(7, 660, 1020),
+			},
+		},
+		"semicolon-separated three-letter day ranges with trailing note": {
+			input: "9am-9pm Mon-Tue; 9am-6pm Wed-Sat; for client use only",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1260),
+				dayOpeningHours(2, 540, 1260),
+				dayOpeningHours(3, 540, 1080),
+				dayOpeningHours(4, 540, 1080),
+				dayOpeningHours(5, 540, 1080),
+				dayOpeningHours(6, 540, 1080),
+			},
+		},
+		"bare T means Tuesday": {
+			input: "9am-9pm M-T",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(1, 540, 1260),
+				dayOpeningHours(2, 540, 1260),
+			},
+		},
+		"bare T range with three-letter abbreviations": {
+			input: "10am-5pm T-F, 10am-5pm Sat-Sun",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(2, 600, 1020),
+				dayOpeningHours(3, 600, 1020),
+				dayOpeningHours(4, 600, 1020),
+				dayOpeningHours(5, 600, 1020),
+				dayOpeningHours(6, 600, 1020),
+				dayOpeningHours(7, 600, 1020),
+			},
+		},
+		"bare T alongside Th in the same string": {
+			input: "10am-5pm T-TH, 10am-9pm F, 10am-5pm Sat-Sun",
+			expectedResult: []OpeningHours{
+				dayOpeningHours(2, 600, 1020),
+				dayOpeningHours(3, 600, 1020),
+				dayOpeningHours(4, 600, 1020),
+				dayOpeningHours(5, 600, 1260),
+				dayOpeningHours(6, 600, 1020),
+				dayOpeningHours(7, 600, 1020),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ParseFreeformOpeningHours(tt.input)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError, err.Error())
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestFreeformOpeningHoursToISOString(t *testing.T) {
+	tests := map[string]struct {
+		input          string
+		expectedResult string
+		expectedError  string
+	}{
+		"9am-9pm": {
+			input:          "9am-9pm",
+			expectedResult: "W1T09:00:00/W1T21:00:00,W2T09:00:00/W2T21:00:00,W3T09:00:00/W3T21:00:00,W4T09:00:00/W4T21:00:00,W5T09:00:00/W5T21:00:00,W6T09:00:00/W6T21:00:00,W7T09:00:00/W7T21:00:00",
+		},
+		"24 hours daily": {
+			input:          "24 hours daily",
+			expectedResult: TwentyFourSevenString,
+		},
+		"invalid input": {
+			input:         "nonsense",
+			expectedError: `unrecognized opening hours format: "nonsense"`,
+		},
+	}
+
+	for name, tt := range tests {
+		tt := tt
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := FreeformOpeningHoursToISOString(tt.input)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError, err.Error())
+				assert.Equal(t, "", result)
+			}
+		})
+	}
+}
+
+func TestParse12HourTime(t *testing.T) {
+	tests := []struct {
+		hourStr        string
+		minuteStr      string
+		meridiem       string
+		expectedResult int
+		expectedError  string
+	}{
+		{"9", "", "am", 540, ""},
+		{"9", "", "pm", 1260, ""},
+		{"12", "", "am", 0, ""},
+		{"12", "", "pm", 720, ""},
+		{"12", "30", "am", 30, ""},
+		{"9", "30", "pm", 1290, ""},
+		{"0", "", "am", 0, "invalid hour value"},
+		{"13", "", "am", 0, "invalid hour value"},
+		{"9", "60", "am", 0, "invalid minute value"},
+		{"9", "", "xx", 0, "invalid meridiem value"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%s:%s%s", tt.hourStr, tt.minuteStr, tt.meridiem), func(t *testing.T) {
+			t.Parallel()
+			result, err := parse12HourTime(tt.hourStr, tt.minuteStr, tt.meridiem)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestParse12HourClosingTime(t *testing.T) {
+	tests := []struct {
+		hourStr        string
+		minuteStr      string
+		meridiem       string
+		expectedResult int
+		expectedError  string
+	}{
+		{"12", "", "am", 1440, ""},
+		{"12", "", "pm", 720, ""},
+		{"9", "", "pm", 1260, ""},
+		{"9", "", "am", 540, ""},
+		{"13", "", "am", 0, "invalid hour value"},
+		{"9", "60", "am", 0, "invalid minute value"},
+		{"9", "", "xx", 0, "invalid meridiem value"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%s:%s%s", tt.hourStr, tt.minuteStr, tt.meridiem), func(t *testing.T) {
+			t.Parallel()
+			result, err := parse12HourClosingTime(tt.hourStr, tt.minuteStr, tt.meridiem)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
 func TestParseMinutesSinceMidnight(t *testing.T) {
 	tests := []struct {
 		hourStr        string


### PR DESCRIPTION
### Add free-form opening hours parsing
**Summary**
Adds ParseFreeformOpeningHours / FreeformOpeningHoursToISOString, which convert human-written opening-hours strings (as commonly seen in POI/EV-charging datasets) into []OpeningHours / the package's ISO-like string format. 

This code was built incrementally with Claude by feeding him over 400 various formats from the AFDC AccessDaysTime data column

**Supported formats**
Every-day shorthand: "9am-9pm", "5am to 10pm daily", "24 hours daily", "24/7"
Day lists and ranges: "9am-9pm M-Th, 9am-6pm F, 9am-5pm Sat", with abbreviations from single-letter (M, F) through three-letter (Mon, Sat) to full names, plus "weekdays"/"every day" keywords
Compound day specs: joined by comma, "and", or "&" — "W-F and Sun", "Mon, Wed and Fri", "M & W"
Overnight/cross-midnight ranges: "10pm-6am" correctly rolls the closing day forward
Multiple time windows sharing one day spec: "12am-7am, 9am-5:30pm, 7:30pm-12am daily", "8am-12pm and 1pm-5pm M-F", "6:30am-6pm & 8pm-10pm daily"
"24 hours <day spec>" as a standalone clause: "3pm-7:45am M-F, 24 hours Sat-Sun"
Free-text notes are dropped, not fatal: semicolon-delimited ("...; for staff use only"), parenthetical ("(May-Sept)"), or glued on with no separator at all ("M-F daily", "daily for guests", "Sat, for client use only") — the parser recovers the longest valid leading day-spec and silently drops the rest
"closed <day>" as an explicit (no-op) exclusion clause
Minor normalizations: 12am as a closing time means end-of-day (24:00), not start-of-day; a bare T means Tuesday (this abbreviation style always spells out Th for Thursday); S-S means Saturday-Sunday; a missing opening-time meridiem defaults to AM ("9-5pm")

**Design notes**
Each format is a small, independently-testable parser function registered in an ordered list (freeformParsers for whole-string formats, segmentParsers for individual clauses within a multi-day string), so new formats can be added without touching existing ones.
Free-text handling deliberately favors silently dropping unresolvable content over erroring — the test samples have far more "real hours + explanatory note" strings than genuinely malformed ones, so a parse failure is more often a false negative than a caught mistake. One consequence: a mistyped day inside an explicit list (e.g. "Mon and Xyz") now resolves to just the valid entries rather than erroring.

**Known unsupported cases (~7 of 472)**
Left as-is, either out of scope or genuinely ambiguous: bare 24-hour-clock times with no am/pm ("7:30-7:30"), non-clock closing times ("...to sunset"), and a couple of strings with no day information at all once the surrounding prose is stripped out.

**Testing**
154 test cases across 11 test functions (go test ./...), including a dedicated TestParseFreeformOpeningHours suite (59 cases) covering every format above plus edge cases (empty input, invalid times, invalid days, wraparound). go vet clean.