### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: |
@@ -28,7 +28,7 @@ jobs:
             **/go.mod
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Enforce standard format
         uses: golangci/golangci-lint-action@v7


### PR DESCRIPTION
Part of an org-wide low-risk major-version audit of pinned GitHub Actions across ParenInc repos. These bumps are mostly Node runtime updates on GitHub's side and have no known breaking changes for this workflow.

- `actions/checkout` v4 -> v7
- `actions/setup-go` v5 -> v7